### PR TITLE
Composing instance id from properties

### DIFF
--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/EurekaConfigurationTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/EurekaConfigurationTest.java
@@ -38,7 +38,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static io.quarkus.eureka.util.HostNameDiscovery.getEurekaInstanceId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -78,7 +77,8 @@ public class EurekaConfigurationTest {
     @DisplayName(value = "reading configuration properties for eureka")
     public void shouldLoadEurekaConfigAndRegisterBeans() {
 
-        wireMockServer.stubFor(delete(urlEqualTo("/eureka/apps/SAMPLE/" + getEurekaInstanceId()))
+        String instanceId = String.join(":", "localhost", "sample", String.valueOf(wireMockServer.port()));
+        wireMockServer.stubFor(delete(urlEqualTo("/eureka/apps/SAMPLE/".concat(instanceId)))
                 .willReturn(aResponse().withHeader("Content-Type", "application/json")
                         .withStatus(200)));
 

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/config/DefaultInstanceInfoContextTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/config/DefaultInstanceInfoContextTest.java
@@ -16,8 +16,74 @@
 
 package io.quarkus.eureka.config;
 
-import static org.junit.jupiter.api.Assertions.*;
+import io.quarkus.eureka.util.HostNameDiscovery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DefaultInstanceInfoContextTest {
+
+    private EurekaConfiguration eurekaConfiguration;
+
+    @BeforeEach
+    void setUp() {
+        eurekaConfiguration = new EurekaConfiguration();
+        eurekaConfiguration.port = 8001;
+        eurekaConfiguration.name = "sample";
+        eurekaConfiguration.vipAddress = "sample";
+        eurekaConfiguration.region = "default";
+        eurekaConfiguration.preferSameZone = true;
+    }
+
+    @Test
+    void shouldBuildInstanceId() {
+        //Given
+        eurekaConfiguration.hostName = "example.com";
+
+        //When
+        InstanceInfoContext instanceInfoContext = new DefaultInstanceInfoContext(eurekaConfiguration);
+
+        //Then
+        assertThat(instanceInfoContext.getInstanceId()).isEqualTo("example.com:sample:8001");
+
+    }
+
+    @Test
+    void shouldInstanceIdBeLowerCase() {
+        //Given
+        eurekaConfiguration.hostName = "EXAMPLE.COM";
+        eurekaConfiguration.name = "SAMPLE";
+
+        //When
+        InstanceInfoContext instanceInfoContext = new DefaultInstanceInfoContext(eurekaConfiguration);
+
+        //Then
+        assertThat(instanceInfoContext.getInstanceId()).isEqualTo("example.com:sample:8001");
+        assertThat(instanceInfoContext.getHostName()).isEqualTo("EXAMPLE.COM");
+
+    }
+
+    @Test
+    void shouldGetDefinedHostname() {
+        //Given
+        eurekaConfiguration.hostName = "example.com";
+
+        //When
+        InstanceInfoContext instanceInfoContext = new DefaultInstanceInfoContext(eurekaConfiguration);
+
+        //Then
+        assertThat(instanceInfoContext.getHostName()).isEqualTo("example.com");
+    }
+
+    @Test
+    void shouldGetHostAddress() {
+
+        //Given && When
+        InstanceInfoContext instanceInfoContext = new DefaultInstanceInfoContext(eurekaConfiguration);
+
+        //Then
+        assertThat(instanceInfoContext.getHostName()).isEqualTo(HostNameDiscovery.getHostname());
+    }
 
 }

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/config/DefaultInstanceInfoContextTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/config/DefaultInstanceInfoContextTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.eureka.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DefaultInstanceInfoContextTest {
+
+}

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperationTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperationTest.java
@@ -18,9 +18,7 @@ package io.quarkus.eureka.operation.heartbeat;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.quarkus.eureka.client.InstanceInfo;
-import io.quarkus.eureka.config.InstanceInfoContext;
 import io.quarkus.eureka.test.config.TestInstanceInfoContext;
-import io.quarkus.eureka.util.HostNameDiscovery;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +28,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.quarkus.eureka.util.HostNameDiscovery.getHostname;
-import static java.lang.String.join;
 
 public class HeartBeatOperationTest {
 

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperationTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperationTest.java
@@ -19,6 +19,7 @@ package io.quarkus.eureka.operation.heartbeat;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import io.quarkus.eureka.client.InstanceInfo;
 import io.quarkus.eureka.config.InstanceInfoContext;
+import io.quarkus.eureka.test.config.TestInstanceInfoContext;
 import io.quarkus.eureka.util.HostNameDiscovery;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,70 +73,4 @@ public class HeartBeatOperationTest {
         wireMockServer.verify(1, putRequestedFor(urlEqualTo(updatePath)));
 
     }
-
-    static class TestInstanceInfoContext implements InstanceInfoContext {
-
-        private final String name;
-        private final int port;
-        private final String instanceId;
-        private final String hostName;
-
-        private TestInstanceInfoContext(final String name, final int port, final String hostName) {
-
-            this.name = name;
-            this.port = port;
-            this.hostName = hostName;
-            this.instanceId = buildInstanceId();
-        }
-
-        public static InstanceInfoContext of(final String name, final int port, final String hostName) {
-
-            return new TestInstanceInfoContext(name, port, hostName);
-        }
-
-        @Override
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public int getPort() {
-            return port;
-        }
-
-        @Override
-        public String getVipAddress() {
-            return name;
-        }
-
-        @Override
-        public String getInstanceId() {
-            return instanceId;
-        }
-
-        @Override
-        public String getHostName() {
-            return hostName;
-        }
-
-        @Override
-        public String getHealthCheckUrl() {
-            return "/info/health";
-        }
-
-        @Override
-        public String getHomePageUrl() {
-            return "/";
-        }
-
-        @Override
-        public String getStatusPageUrl() {
-            return "/info/status";
-        }
-
-        private String buildInstanceId() {
-            return join(":", this.getHostName(), this.getName(), String.valueOf(this.getPort())).toLowerCase();
-        }
-    }
-
 }

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperationTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperationTest.java
@@ -29,6 +29,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.quarkus.eureka.util.HostNameDiscovery.getHostname;
+import static java.lang.String.join;
 
 public class HeartBeatOperationTest {
 
@@ -60,8 +61,9 @@ public class HeartBeatOperationTest {
         wireMockServer.stubFor(put(urlEqualTo(updatePath))
                 .willReturn(aResponse().withStatus(200)));
 
-        InstanceInfo instanceInfo = InstanceInfo.of(TestInstanceInfoContext.of("SAMPLE", wireMockServer.port(),
-                instanceId, getHostname()));
+        InstanceInfo instanceInfo = InstanceInfo.of(
+                TestInstanceInfoContext.of("SAMPLE", wireMockServer.port(), getHostname())
+        );
 
         //When
         heartBeatOperation.heartbeat(serverUrl.concat("/eureka"), instanceInfo);
@@ -78,18 +80,17 @@ public class HeartBeatOperationTest {
         private final String instanceId;
         private final String hostName;
 
-        private TestInstanceInfoContext(final String name, final int port,
-                                        final String instanceId, final String hostName) {
+        private TestInstanceInfoContext(final String name, final int port, final String hostName) {
+
             this.name = name;
             this.port = port;
-            this.instanceId = instanceId;
             this.hostName = hostName;
-            HostNameDiscovery.setEurekaInstanceId(instanceId);
+            this.instanceId = buildInstanceId();
         }
 
-        public static InstanceInfoContext of(final String name, final int port,
-                                             final String instanceId, final String hostName) {
-            return new TestInstanceInfoContext(name, port, instanceId, hostName);
+        public static InstanceInfoContext of(final String name, final int port, final String hostName) {
+
+            return new TestInstanceInfoContext(name, port, hostName);
         }
 
         @Override
@@ -130,6 +131,10 @@ public class HeartBeatOperationTest {
         @Override
         public String getStatusPageUrl() {
             return "/info/status";
+        }
+
+        private String buildInstanceId() {
+            return join(":", this.getHostName(), this.getName(), String.valueOf(this.getPort())).toLowerCase();
         }
     }
 

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperationTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperationTest.java
@@ -80,7 +80,7 @@ class HeartBeatOperationTest {
         final String instanceId = getHostname() + ":" + "other" + ":" + wireMockServer.port();
         final String updatePath = "/eureka/apps/OTHER/" + instanceId;
         wireMockServer.stubFor(put(urlEqualTo(updatePath))
-                .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+                .willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
 
         InstanceInfo instanceInfo = InstanceInfo.of(
                 TestInstanceInfoContext.of("OTHER", wireMockServer.port(), getHostname())
@@ -91,7 +91,5 @@ class HeartBeatOperationTest {
 
         //Then
         wireMockServer.verify(1, putRequestedFor(urlEqualTo(updatePath)));
-        //TODO how to assert log output to print a processingException. Or shall we throw the exception.
-        // this would end up in traces for the user output
     }
 }

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/remove/RemoveInstanceOperationTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/operation/remove/RemoveInstanceOperationTest.java
@@ -17,7 +17,6 @@
 package io.quarkus.eureka.operation.remove;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import io.quarkus.eureka.util.HostNameDiscovery;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ class RemoveInstanceOperationTest {
 
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
 
         this.removeInstanceOperation = new RemoveInstanceOperation();
         this.wireMockServer = new WireMockServer(8002);
@@ -54,16 +53,16 @@ class RemoveInstanceOperationTest {
     }
 
     @Test
-    public void shouldCallDeleteToRemoveInstance() {
+    void shouldCallDeleteToRemoveInstance() {
         //Given
-        final String deletePath = "/eureka/apps/SAMPLE/" + getHostname() + ":" + "sample" + ":" + wireMockServer.port();
-        HostNameDiscovery.setEurekaInstanceId(getHostname()+ ":" + "sample" + ":" + wireMockServer.port());
+        String instanceId = getHostname() + ":" + "sample" + ":" + wireMockServer.port();
+        String deletePath = "/eureka/apps/SAMPLE/".concat(instanceId);
         wireMockServer.stubFor(delete(urlEqualTo(deletePath))
                 .willReturn(aResponse().withStatus(200)));
 
 
         //When
-        removeInstanceOperation.remove(serverUrl.concat("/eureka"), "SAMPLE");
+        removeInstanceOperation.remove(serverUrl.concat("/eureka"), "SAMPLE", instanceId);
 
         //Then
         wireMockServer.verify(1, deleteRequestedFor(urlEqualTo(deletePath)));

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/registration/EurekaRegistrationServiceTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/registration/EurekaRegistrationServiceTest.java
@@ -26,6 +26,7 @@ import io.quarkus.eureka.operation.OperationFactory;
 import io.quarkus.eureka.operation.heartbeat.HeartBeatOperation;
 import io.quarkus.eureka.operation.query.MultipleInstanceQueryOperation;
 import io.quarkus.eureka.operation.register.RegisterOperation;
+import io.quarkus.eureka.test.config.TestInstanceInfoContext;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,7 +81,7 @@ class EurekaRegistrationServiceTest {
         wireMockServer = new WireMockServer(port);
         wireMockServer.start();
 
-        InstanceInfoContext instanceInfoContext = new TestInstanceInfoContext(
+        InstanceInfoContext instanceInfoContext = TestInstanceInfoContext.of(
                 appName, port, appName, hostname, "/", "/info/status", "/info/health"
         );
         scheduledExecutorService = Mockito.mock(ScheduledExecutorService.class);
@@ -220,74 +221,6 @@ class EurekaRegistrationServiceTest {
         wireMockServer.verify(0,
                 postRequestedFor(urlEqualTo(join("/", "/eureka/apps", appName.toUpperCase())))
         );
-    }
-
-    static class TestInstanceInfoContext implements InstanceInfoContext {
-        private final String name;
-        private final int port;
-        private final String vipAddress;
-        private final String instanceId;
-        private final String hostName;
-        private final String homePageUrl;
-        private final String statusPageUrl;
-        private final String healthCheckUrl;
-
-        TestInstanceInfoContext(String name, int port, String vipAddress, String hostName,
-                                String homePageUrl, String statusPageUrl, String healthCheckUrl) {
-            this.name = name;
-            this.port = port;
-            this.vipAddress = vipAddress;
-            this.homePageUrl = homePageUrl;
-            this.statusPageUrl = statusPageUrl;
-            this.healthCheckUrl = healthCheckUrl;
-            this.hostName = hostName;
-            this.instanceId = buildInstanceId();
-        }
-
-        @Override
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public int getPort() {
-            return port;
-        }
-
-        @Override
-        public String getVipAddress() {
-            return vipAddress;
-        }
-
-        @Override
-        public String getInstanceId() {
-            return instanceId;
-        }
-
-        @Override
-        public String getHostName() {
-            return hostName;
-        }
-
-        @Override
-        public String getHomePageUrl() {
-            return homePageUrl;
-        }
-
-        @Override
-        public String getStatusPageUrl() {
-            return statusPageUrl;
-        }
-
-        @Override
-        public String getHealthCheckUrl() {
-            return healthCheckUrl;
-        }
-
-        private String buildInstanceId() {
-            return join(":", this.getHostName(), this.getName(), String.valueOf(this.getPort())).toLowerCase();
-        }
-
     }
 
 }

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/registration/EurekaRegistrationServiceTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/registration/EurekaRegistrationServiceTest.java
@@ -26,7 +26,6 @@ import io.quarkus.eureka.operation.OperationFactory;
 import io.quarkus.eureka.operation.heartbeat.HeartBeatOperation;
 import io.quarkus.eureka.operation.query.MultipleInstanceQueryOperation;
 import io.quarkus.eureka.operation.register.RegisterOperation;
-import io.quarkus.eureka.util.HostNameDiscovery;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,7 +52,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
-public class EurekaRegistrationServiceTest {
+class EurekaRegistrationServiceTest {
 
     private final String appName = "sample";
 
@@ -75,14 +74,14 @@ public class EurekaRegistrationServiceTest {
     private final Logger logger = Logger.getLogger(this.getClass().getName());
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         logger.info("Starting mock server.");
 
         wireMockServer = new WireMockServer(port);
         wireMockServer.start();
 
         InstanceInfoContext instanceInfoContext = new TestInstanceInfoContext(
-                appName, port, appName, hostname + ":" + appName + ":" + port, hostname, "/", "/info/status", "/info/health"
+                appName, port, appName, hostname, "/", "/info/status", "/info/health"
         );
         scheduledExecutorService = Mockito.mock(ScheduledExecutorService.class);
         registerOperation = new RegisterOperation();
@@ -111,12 +110,12 @@ public class EurekaRegistrationServiceTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         wireMockServer.stop();
     }
 
     @Test
-    public void shouldRegisterAService() {
+    void shouldRegisterAService() {
         logger.info("shouldRegisterAService test.");
         wireMockServer.stubFor(get(urlEqualTo("/info/health"))
                 .willReturn(aResponse().withHeader("Content-Type", "application/json")
@@ -140,7 +139,7 @@ public class EurekaRegistrationServiceTest {
     }
 
     @Test
-    public void shouldFailWhenInstanceHealthCheckNotImplemented() {
+    void shouldFailWhenInstanceHealthCheckNotImplemented() {
         logger.info("shouldFailWhenInstanceHealthCheckNotImplemented test.");
         wireMockServer.stubFor(get(urlEqualTo("/info/health"))
                 .willReturn(aResponse().withHeader("Content-Type", "application/json")
@@ -154,7 +153,7 @@ public class EurekaRegistrationServiceTest {
     }
 
     @Test
-    public void shouldTryToRegisterWhenAppIsNotReachableInEureka() {
+    void shouldTryToRegisterWhenAppIsNotReachableInEureka() {
         logger.info("shouldTryToRegisterWhenAppIsNotReachableInEureka test.");
         wireMockServer.stubFor(get(urlEqualTo("/info/health"))
                 .willReturn(aResponse().withHeader("Content-Type", "application/json")
@@ -189,7 +188,7 @@ public class EurekaRegistrationServiceTest {
 
 
     @Test
-    public void shouldHaveServiceRegistered() {
+    void shouldHaveServiceRegistered() {
         logger.info("shouldHaveServiceRegistered test.");
         wireMockServer.stubFor(get(urlEqualTo("/info/health"))
                 .willReturn(aResponse().withHeader("Content-Type", "application/json")
@@ -233,7 +232,7 @@ public class EurekaRegistrationServiceTest {
         private final String statusPageUrl;
         private final String healthCheckUrl;
 
-        TestInstanceInfoContext(String name, int port, String vipAddress, String instanceId, String hostName,
+        TestInstanceInfoContext(String name, int port, String vipAddress, String hostName,
                                 String homePageUrl, String statusPageUrl, String healthCheckUrl) {
             this.name = name;
             this.port = port;
@@ -242,8 +241,7 @@ public class EurekaRegistrationServiceTest {
             this.statusPageUrl = statusPageUrl;
             this.healthCheckUrl = healthCheckUrl;
             this.hostName = hostName;
-            this.instanceId = instanceId;
-            HostNameDiscovery.setEurekaInstanceId(instanceId);
+            this.instanceId = buildInstanceId();
         }
 
         @Override
@@ -285,6 +283,11 @@ public class EurekaRegistrationServiceTest {
         public String getHealthCheckUrl() {
             return healthCheckUrl;
         }
+
+        private String buildInstanceId() {
+            return join(":", this.getHostName(), this.getName(), String.valueOf(this.getPort())).toLowerCase();
+        }
+
     }
 
 }

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/test/config/TestInstanceInfoContext.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/test/config/TestInstanceInfoContext.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.quarkus.eureka.test.config;
+
+import io.quarkus.eureka.config.InstanceInfoContext;
+
+import static java.lang.String.join;
+
+public class TestInstanceInfoContext implements InstanceInfoContext {
+
+    private final String name;
+    private final int port;
+    private final String vipAddress;
+    private final String instanceId;
+    private final String hostName;
+    private final String homePageUrl;
+    private final String statusPageUrl;
+    private final String healthCheckUrl;
+
+    private TestInstanceInfoContext(String name, int port, String vipAddress, String hostName,
+                                    String homePageUrl, String statusPageUrl, String healthCheckUrl) {
+        this.name = name;
+        this.port = port;
+        this.vipAddress = vipAddress;
+        this.homePageUrl = homePageUrl;
+        this.statusPageUrl = statusPageUrl;
+        this.healthCheckUrl = healthCheckUrl;
+        this.hostName = hostName;
+        this.instanceId = buildInstanceId();
+    }
+
+    public static InstanceInfoContext of(final String name, final int port, final String hostName) {
+
+        return new TestInstanceInfoContext(name, port, name, hostName, "/", "/info/status", "/info/health");
+    }
+
+    public static InstanceInfoContext of(final String name, final int port, final String vipAddress,
+                                         final String hostName, final String homePageUrl, final String statusPageUrl,
+                                         final String healthCheckUrl) {
+        return new TestInstanceInfoContext(
+                name, port, vipAddress, hostName, homePageUrl, statusPageUrl, healthCheckUrl
+        );
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public String getVipAddress() {
+        return vipAddress;
+    }
+
+    @Override
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    @Override
+    public String getHostName() {
+        return hostName;
+    }
+
+    @Override
+    public String getHomePageUrl() {
+        return homePageUrl;
+    }
+
+    @Override
+    public String getStatusPageUrl() {
+        return statusPageUrl;
+    }
+
+    @Override
+    public String getHealthCheckUrl() {
+        return healthCheckUrl;
+    }
+
+    private String buildInstanceId() {
+        return join(":", this.getHostName(), this.getName(), String.valueOf(this.getPort())).toLowerCase();
+    }
+}

--- a/quarkus-eureka-deployment/src/test/resources/eureka-config.properties
+++ b/quarkus-eureka-deployment/src/test/resources/eureka-config.properties
@@ -16,6 +16,8 @@
 
 quarkus.eureka.port=8001
 quarkus.eureka.name=sample
+quarkus.eureka.host-name=127.0.0.1
+quarkus.eureka.instance-id=127.0.0.1:sample:8001
 quarkus.eureka.vip-address=sample
 quarkus.eureka.region=default
 quarkus.eureka.prefer-same-zone=true

--- a/quarkus-eureka-deployment/src/test/resources/eureka-config.properties
+++ b/quarkus-eureka-deployment/src/test/resources/eureka-config.properties
@@ -16,8 +16,6 @@
 
 quarkus.eureka.port=8001
 quarkus.eureka.name=sample
-quarkus.eureka.host-name=127.0.0.1
-quarkus.eureka.instance-id=127.0.0.1:sample:8001
 quarkus.eureka.vip-address=sample
 quarkus.eureka.region=default
 quarkus.eureka.prefer-same-zone=true

--- a/quarkus-eureka-deployment/src/test/resources/eureka-config.properties
+++ b/quarkus-eureka-deployment/src/test/resources/eureka-config.properties
@@ -1,23 +1,6 @@
-#
-# Copyright 2019 the original author or authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 quarkus.eureka.port=8001
 quarkus.eureka.name=sample
 quarkus.eureka.host-name=127.0.0.1
-quarkus.eureka.instance-id=127.0.0.1:sample:8001
 quarkus.eureka.vip-address=sample
 quarkus.eureka.region=default
 quarkus.eureka.prefer-same-zone=true

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/EurekaProducer.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/EurekaProducer.java
@@ -51,9 +51,9 @@ public class EurekaProducer {
     EurekaClient eurekaClient(InjectionPoint ip) {
         LoadBalancer loadBalancer;
         ServiceDiscovery serviceDiscovery = new ServiceDiscovery(serviceLocationConfig, operationFactory);
-        if(ip.getAnnotated().getAnnotation(LoadBalanced.class).type() == LoadBalancerType.RANDOM)
+        if (ip.getAnnotated().getAnnotation(LoadBalanced.class).type() == LoadBalancerType.RANDOM)
             loadBalancer = new Random(serviceDiscovery);
-        else if(ip.getAnnotated().getAnnotation(LoadBalanced.class).type() == LoadBalancerType.ROUND_ROBIN)
+        else if (ip.getAnnotated().getAnnotation(LoadBalanced.class).type() == LoadBalancerType.ROUND_ROBIN)
             loadBalancer = new RoundRobin(serviceDiscovery);
         else
             loadBalancer = new Random(serviceDiscovery);
@@ -63,14 +63,16 @@ public class EurekaProducer {
     @Produces
     EurekaClient eurekaClient() {
         ServiceDiscovery serviceDiscovery = new ServiceDiscovery(serviceLocationConfig, operationFactory);
-        return new EurekaClient( new Random(serviceDiscovery));
+        return new EurekaClient(new Random(serviceDiscovery));
     }
 
     void onApplicationStop(@Observes ShutdownEvent shutdownEvent) {
         logger.info("application finished... now we have to deregister from Eureka...");
         String appId = instanceInfo.getApp();
-        serviceLocationConfig.getLocations()
-                .forEach(location -> operationFactory.get(RemoveInstanceOperation.class).remove(location, appId));
+        String instanceId = instanceInfo.getInstanceId();
+        serviceLocationConfig.getLocations().forEach(location ->
+                operationFactory.get(RemoveInstanceOperation.class).remove(location, appId, instanceId)
+        );
     }
 
     void setInstanceInfo(final InstanceInfo instanceInfo) {

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/client/InstanceInfo.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/client/InstanceInfo.java
@@ -18,7 +18,9 @@ package io.quarkus.eureka.client;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.quarkus.eureka.config.InstanceInfoContext;
+
 import java.util.function.Function;
+
 import static java.lang.String.format;
 
 @JsonPropertyOrder({

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/client/loadBalancer/LoadBalanced.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/client/loadBalancer/LoadBalanced.java
@@ -18,11 +18,11 @@ package io.quarkus.eureka.client.loadBalancer;
 
 import javax.enterprise.util.Nonbinding;
 import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.annotation.Documented;
 
 @Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/DefaultInstanceInfoContext.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/DefaultInstanceInfoContext.java
@@ -18,6 +18,9 @@ package io.quarkus.eureka.config;
 
 import io.quarkus.eureka.util.HostNameDiscovery;
 
+import java.util.Optional;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.join;
 
 public class DefaultInstanceInfoContext implements InstanceInfoContext {
@@ -38,7 +41,7 @@ public class DefaultInstanceInfoContext implements InstanceInfoContext {
         this.homePageUrl = eurekaConfiguration.homePageUrl;
         this.statusPageUrl = eurekaConfiguration.statusPageUrl;
         this.healthCheckUrl = eurekaConfiguration.healthCheckUrl;
-        this.hostName = HostNameDiscovery.getHostname();
+        this.hostName = resolveHostname(eurekaConfiguration.hostName);
         this.instanceId = buildInstanceId();
     }
 
@@ -76,6 +79,12 @@ public class DefaultInstanceInfoContext implements InstanceInfoContext {
 
     public String getHealthCheckUrl() {
         return healthCheckUrl;
+    }
+
+    private String resolveHostname(final String hostName) {
+        return Optional.ofNullable(hostName)
+                .filter(hn -> !isNullOrEmpty(hn))
+                .orElseGet(HostNameDiscovery::getHostname);
     }
 
     private String buildInstanceId() {

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/DefaultInstanceInfoContext.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/DefaultInstanceInfoContext.java
@@ -18,6 +18,8 @@ package io.quarkus.eureka.config;
 
 import io.quarkus.eureka.util.HostNameDiscovery;
 
+import static java.lang.String.join;
+
 public class DefaultInstanceInfoContext implements InstanceInfoContext {
 
     private final String name;
@@ -36,8 +38,8 @@ public class DefaultInstanceInfoContext implements InstanceInfoContext {
         this.homePageUrl = eurekaConfiguration.homePageUrl;
         this.statusPageUrl = eurekaConfiguration.statusPageUrl;
         this.healthCheckUrl = eurekaConfiguration.healthCheckUrl;
-        this.hostName = HostNameDiscovery.getHostname(eurekaConfiguration.hostName);
-        this.instanceId = HostNameDiscovery.buildInstanceId(this, eurekaConfiguration.instanceId);
+        this.hostName = HostNameDiscovery.getHostname();
+        this.instanceId = buildInstanceId();
     }
 
     public static InstanceInfoContext withConfiguration(final EurekaConfiguration eurekaConfiguration) {
@@ -75,4 +77,9 @@ public class DefaultInstanceInfoContext implements InstanceInfoContext {
     public String getHealthCheckUrl() {
         return healthCheckUrl;
     }
+
+    private String buildInstanceId() {
+        return join(":", this.getHostName(), this.getName(), String.valueOf(this.getPort())).toLowerCase();
+    }
+
 }

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaConfiguration.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaConfiguration.java
@@ -44,18 +44,6 @@ public class EurekaConfiguration {
     String vipAddress;
 
     /**
-     * Name of instance id which instance will be registered to Eureka
-     */
-    @ConfigItem
-    String instanceId;
-
-    /**
-     * The hostname, otherwise it will be guest from OS primitives
-     */
-    @ConfigItem
-    String hostName;
-
-    /**
      * if AWS environment, in which region this registry service is
      */
     @ConfigItem

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaConfiguration.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaConfiguration.java
@@ -44,6 +44,18 @@ public class EurekaConfiguration {
     String vipAddress;
 
     /**
+     * Name of instance id which instance will be registered to Eureka
+     */
+    @ConfigItem
+    String instanceId;
+
+    /**
+     * The hostname, otherwise it will be guest from OS primitives
+     */
+    @ConfigItem
+    String hostName;
+
+    /**
      * if AWS environment, in which region this registry service is
      */
     @ConfigItem

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaConfiguration.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaConfiguration.java
@@ -44,12 +44,6 @@ public class EurekaConfiguration {
     String vipAddress;
 
     /**
-     * Name of instance id which instance will be registered to Eureka
-     */
-    @ConfigItem
-    String instanceId;
-
-    /**
      * The hostname, otherwise it will be guest from OS primitives
      */
     @ConfigItem

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperation.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperation.java
@@ -24,6 +24,7 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.Map;
 import java.util.logging.Logger;
 

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperation.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/operation/heartbeat/HeartBeatOperation.java
@@ -18,7 +18,6 @@ package io.quarkus.eureka.operation.heartbeat;
 
 import io.quarkus.eureka.client.InstanceInfo;
 import io.quarkus.eureka.operation.Operation;
-import io.quarkus.eureka.util.HostNameDiscovery;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 
 import javax.ws.rs.ProcessingException;
@@ -39,7 +38,7 @@ public class HeartBeatOperation implements Operation {
     public void heartbeat(final String location, final InstanceInfo instanceInfo) {
         String appId = instanceInfo.getApp();
         logger.info(format("%s heartbeat to %s", appId, location));
-        final String path = String.join("/", "apps", appId, HostNameDiscovery.getEurekaInstanceId());
+        final String path = String.join("/", "apps", appId, instanceInfo.getInstanceId());
         Map<String, InstanceInfo> instance = singletonMap("instance", instanceInfo.withStatus(UP));
         Client client = ResteasyClientBuilder.newClient();
 

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/operation/remove/RemoveInstanceOperation.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/operation/remove/RemoveInstanceOperation.java
@@ -17,7 +17,6 @@
 package io.quarkus.eureka.operation.remove;
 
 import io.quarkus.eureka.operation.Operation;
-import io.quarkus.eureka.util.HostNameDiscovery;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 
 import javax.ws.rs.ProcessingException;
@@ -31,9 +30,9 @@ public class RemoveInstanceOperation implements Operation {
 
     private final Logger logger = Logger.getLogger(this.getClass().getName());
 
-    public void remove(final String location, final String appId) {
+    public void remove(final String location, final String appId, final String instanceId) {
         logger.info(format("Deregistering %s from %s", appId, location));
-        final String path = String.join("/", "apps", appId, HostNameDiscovery.getEurekaInstanceId());
+        final String path = String.join("/", "apps", appId, instanceId);
         Client client = ResteasyClientBuilder.newClient();
 
         try {

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/util/HostNameDiscovery.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/util/HostNameDiscovery.java
@@ -16,8 +16,6 @@
 
 package io.quarkus.eureka.util;
 
-import io.quarkus.eureka.config.InstanceInfoContext;
-
 import java.net.InetAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
@@ -29,21 +27,6 @@ import java.util.List;
 public class HostNameDiscovery {
 
     private static String HOSTNAME;
-    private static String INSTANCEID;
-
-    public static String buildInstanceId(final InstanceInfoContext instanceInfoCtx, final String instanceId) {
-        return INSTANCEID = instanceId == null ?
-                getHostname() + ":" + instanceInfoCtx.getName() + ":" + instanceInfoCtx.getPort()
-                : instanceId;
-    }
-
-    public static String getEurekaInstanceId() {
-        return INSTANCEID;
-    }
-
-    public static void setEurekaInstanceId(String instanceId) {
-        HostNameDiscovery.INSTANCEID = instanceId;
-    }
 
     public static String getHostname() {
         if (HOSTNAME != null && !HOSTNAME.trim().equals("")) {

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/util/HostNameDiscovery.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/util/HostNameDiscovery.java
@@ -29,22 +29,14 @@ public class HostNameDiscovery {
     private static String HOSTNAME;
 
     public static String getHostname() {
-        if (HOSTNAME != null && !HOSTNAME.trim().equals("")) {
-            return HOSTNAME;
+        if (HOSTNAME == null || HOSTNAME.trim().equals("")) {
+            HOSTNAME = HostNameDiscovery.getNetworkInterfaces().stream()
+                    .filter(HostNameDiscovery::hasBroadcast)
+                    .map(HostNameDiscovery::extractHostname)
+                    .findFirst()
+                    .orElseGet(HostNameDiscovery::getLocalHost);
         }
-        HOSTNAME = HostNameDiscovery.getNetworkInterfaces().stream()
-                .filter(HostNameDiscovery::hasBroadcast)
-                .map(HostNameDiscovery::extractHostname)
-                .findFirst()
-                .orElseGet(HostNameDiscovery::getLocalHost);
         return HOSTNAME;
-    }
-
-    public static String getHostname(String hostname) {
-        if (hostname != null && !hostname.trim().equals("")) {
-            HOSTNAME = hostname;
-        }
-        return getHostname();
     }
 
     private static List<NetworkInterface> getNetworkInterfaces() {


### PR DESCRIPTION
@angelo147 I have been taking a look how to polish a bit the code, and I have done the following changes:
- as we were creating `TestInstanceInfoContext` in two different places I have extracted it into a different file to be reusable

- instance id is made of properties which were already in configuration, plus the hostname from which the application is deployed. So, `hostname` depends on the host, configure it is too hard to maintain as you don't know the target.

- Removing instance from eureka, injecting which is its `instace_id`

what do you think of this changes? do you think this might clash somehow with your ideas?

Cheers.