### PR TITLE
Registrationloop ends due exception on error fetching eureka

### DIFF
--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/operation/query/MultipleInstanceQueryOperation.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/operation/query/MultipleInstanceQueryOperation.java
@@ -19,13 +19,21 @@ package io.quarkus.eureka.operation.query;
 public class MultipleInstanceQueryOperation extends QueryOperation {
 
     public ApplicationsResult findAllInstances(final String location) {
-        final String path = "apps";
-        return query(location, path, ApplicationsResult.class);
+        try {
+            final String path = "apps";
+            return query(location, path, ApplicationsResult.class);
+        } catch(Exception e) {
+            return ApplicationsResult.error();
+        }
     }
 
     public ApplicationResult findInstance(final String location, final String appId) {
-        final String path = String.join("/", "apps", appId);
-        return query(location, path, ApplicationResult.class);
+        try {
+            final String path = String.join("/", "apps", appId);
+            return query(location, path, ApplicationResult.class);
+        } catch(Exception e) {
+            return ApplicationResult.error();
+        }
     }
 
     @Override


### PR DESCRIPTION
The query method in the instance calls throws an uncatched exception. In the case of an eureka outage/restart. This breaks the main scheduled task in EurekaRegistrationService.

Now: The eureka client stops sending Heartbeats and Registation requests.

expectation: a new try every 40s 

Fix: catch the exception and return an normal error