### PR TITLE
Fixed native build registration issue

### DIFF
--- a/quarkus-eureka-deployment/src/main/java/io/quarkus/eureka/EurekaInfoProcessor.java
+++ b/quarkus-eureka-deployment/src/main/java/io/quarkus/eureka/EurekaInfoProcessor.java
@@ -16,6 +16,8 @@
 
 package io.quarkus.eureka;
 
+import java.util.ArrayList;
+
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.BeanContainerBuildItem;
 import io.quarkus.arc.deployment.BeanContainerListenerBuildItem;
@@ -24,6 +26,10 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
+import io.quarkus.eureka.client.DataCenterInfo;
+import io.quarkus.eureka.client.InstanceInfo;
+import io.quarkus.eureka.client.PortEnableInfo;
 import io.quarkus.eureka.config.EurekaRuntimeConfiguration;
 
 
@@ -55,5 +61,14 @@ public class EurekaInfoProcessor {
         AdditionalBeanBuildItem eurekaBuildItem = AdditionalBeanBuildItem.unremovableOf(EurekaProducer.class);
         additionalBeanProducer.produce(eurekaBuildItem);
     }
+
+	@BuildStep
+	public ReflectiveClassBuildItem registerForReflection() {
+		ArrayList<String> dtos = new ArrayList<>();  
+		dtos.add(InstanceInfo.class.getName());
+		dtos.add(DataCenterInfo.class.getName());
+		dtos.add(PortEnableInfo.class.getName());
+		return new ReflectiveClassBuildItem(true, true, dtos.toArray(new String[dtos.size()]));
+	}
 
 }


### PR DESCRIPTION
Fixes the issue referenced by #24. This issue was caused by the `InstanceInfo`, `DataCenterInfo` and `PortEnableInfo` objects not being registered for reflection in the extension's deployment (ref: https://quarkus.io/guides/writing-native-applications-tips#register-reflection). 

Not registering objects to be serialized into JSON can sometimes lead to silent runtime errors that causes the objects to be serialized as an empty JSON string (ref: https://quarkus.io/guides/writing-native-applications-tips#registering-for-reflection). This caused the `RegisterOperation` to serialize the `InstanceInfo` object as an empty JSON string when running in native mode.