### PR TITLE
Added support advertising for the IP addresses of services rather than host name

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -53,13 +53,13 @@ Including the extension in your application, the next dependency needs to be add
 <dependency>
     <groupId>com.github.fmcejudo</groupId>
     <artifactId>quarkus-eureka</artifactId>
-    <version>0.0.10</version>
+    <version>0.0.11</version>
 </dependency>
 ----
 
 An alternative way to do this is through `maven` quarkus tool as:
 
-`mvn quarkus:add-extension -Dextension="com.github.fmcejudo:quarkus-eureka:0.0.10"`
+`mvn quarkus:add-extension -Dextension="com.github.fmcejudo:quarkus-eureka:0.0.11"`
 
 
 [NOTE]
@@ -78,6 +78,7 @@ your quarkus `application.properties`:
 ----
 quarkus.eureka.port= <your application port, it should match with quarkus.http.port. If it does not exist,it takes quarkus.http.port>
 quarkus.eureka.hostname= <your application address. By default the host where the application has started up>
+quarkus.eureka.prefer-ip-address= <whether or not to override hostname with the application LAN IP address. By default this is set to false>
 quarkus.eureka.name= <name of your application in Eureka. It takes quarkus.application.name if it does not exist>
 quarkus.eureka.vip-address= <how your application is recognised by clients>
 quarkus.eureka.home-page-url= <home path of your application>
@@ -108,6 +109,7 @@ Having as default values for remaining properties the following:
 [source,properties]
 ----
 quarkus.eureka.host-name=<host address>
+quarkus.eureka.prefer-ip-address=false
 quarkus.eureka.port=${quarkus.http.port}
 quarkus.eureka.name=${quarkus.application.name}
 quarkus.eureka.home-page-url=/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.fmcejudo</groupId>
     <artifactId>quarkus-eureka-parent</artifactId>
-    <version>0.0.11-SNAPSHOT</version>
+    <version>0.0.12-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>quarkus-eureka-parent</name>
     <description>Quarkus plugin to integrate with Eureka Server</description>

--- a/quarkus-eureka-deployment/pom.xml
+++ b/quarkus-eureka-deployment/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>quarkus-eureka-parent</artifactId>
         <groupId>com.github.fmcejudo</groupId>
-        <version>0.0.11-SNAPSHOT</version>
+        <version>0.0.12-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/config/DefaultInstanceInfoContextTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/config/DefaultInstanceInfoContextTest.java
@@ -87,4 +87,14 @@ class DefaultInstanceInfoContextTest {
         assertThat(instanceInfoContext.getHostName()).isEqualTo(HostNameDiscovery.getHostname());
     }
 
+    @Test
+    void shouldGetLocalAddress() {
+    	eurekaRuntimeConfiguration.preferIpAddress = true;
+
+        //Given && When
+        InstanceInfoContext instanceInfoContext = new DefaultInstanceInfoContext(eurekaRuntimeConfiguration);
+
+        //Then
+        assertThat(instanceInfoContext.getHostName()).isEqualTo(HostNameDiscovery.getLocalHost());
+    }
 }

--- a/quarkus-eureka/pom.xml
+++ b/quarkus-eureka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>quarkus-eureka-parent</artifactId>
         <groupId>com.github.fmcejudo</groupId>
-        <version>0.0.11-SNAPSHOT</version>
+        <version>0.0.12-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/DefaultInstanceInfoContext.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/DefaultInstanceInfoContext.java
@@ -16,12 +16,9 @@
 
 package io.quarkus.eureka.config;
 
-import io.quarkus.eureka.util.HostNameDiscovery;
-
-import java.util.Optional;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.join;
+
+import io.quarkus.eureka.util.HostNameDiscovery;
 
 public class DefaultInstanceInfoContext implements InstanceInfoContext {
 
@@ -41,7 +38,9 @@ public class DefaultInstanceInfoContext implements InstanceInfoContext {
         this.homePageUrl = eurekaRuntimeConfiguration.homePageUrl;
         this.statusPageUrl = eurekaRuntimeConfiguration.statusPageUrl;
         this.healthCheckUrl = eurekaRuntimeConfiguration.healthCheckUrl;
-        this.hostName = eurekaRuntimeConfiguration.hostName;
+		this.hostName = eurekaRuntimeConfiguration.preferIpAddress
+				? HostNameDiscovery.getLocalHost()
+				: eurekaRuntimeConfiguration.hostName;
         this.instanceId = buildInstanceId();
     }
 

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaRuntimeConfiguration.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaRuntimeConfiguration.java
@@ -53,6 +53,12 @@ public class EurekaRuntimeConfiguration {
     @ConfigItem
     String hostName;
 
+	/**
+	 * Determines if the local ip address should be used instead of the hostName.
+	 */
+    @ConfigItem
+    boolean preferIpAddress;
+
     /**
      * if AWS environment, in which region this registry service is
      */
@@ -90,8 +96,9 @@ public class EurekaRuntimeConfiguration {
     String healthCheckUrl;
 
     public static class NetworkConverter implements Converter<String> {
+		private static final long serialVersionUID = -423310887944694372L;
 
-        @Override
+		@Override
         public String convert(final String hostname) {
             if (hostname != null && !hostname.trim().isEmpty()) {
                 return hostname;

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/util/HostNameDiscovery.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/util/HostNameDiscovery.java
@@ -39,6 +39,14 @@ public class HostNameDiscovery {
         return HOSTNAME;
     }
 
+    public static String getLocalHost() {
+        try {
+            return InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private static List<NetworkInterface> getNetworkInterfaces() {
         try {
             return Collections.list(NetworkInterface.getNetworkInterfaces());
@@ -52,14 +60,6 @@ public class HostNameDiscovery {
         return networkInterface != null
                 && networkInterface.getInterfaceAddresses().stream().anyMatch(ia -> ia.getBroadcast() != null);
 
-    }
-
-    private static String getLocalHost() {
-        try {
-            return InetAddress.getLocalHost().getHostAddress();
-        } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private static String extractHostname(final NetworkInterface networkInterface) {


### PR DESCRIPTION
Details on the why can be found in #30.

I've essentially added the configurable property `quarkus.eureka.prefer-ip-address` that allows a eureka client to advertise the host's IP address rather than the host name. I also updated the relevant README entries and upped the version to 0.0.12-SNAPSHOT since 0.0.11 has bee previously released.