### PR TITLE
Registration first health check initial delay of 3 seconds can be overridden with quarkus.eureka.health-check-initial-delay

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,7 +77,7 @@ your quarkus `application.properties`:
 
 [source,properties]
 ----
-quarkus.eureka.enable=<boolean to tell the application wheter register or not in Eureka. Default to true>
+quarkus.eureka.enable=<boolean to tell the application wether to register or not in Eureka. Default to true>
 quarkus.eureka.port= <your application port, it should match with quarkus.http.port. If it does not exist,it takes quarkus.http.port>
 quarkus.eureka.hostname= <your application address. By default the host where the application has started up>
 quarkus.eureka.context-path= <your application context path, using the default one ${quarkus.http.root-path:/}>
@@ -91,6 +91,7 @@ quarkus.eureka.region=default
 quarkus.eureka.prefer-same-zone=true
 quarkus.eureka.service-url.default=<urls of your Eureka instances. ie: http://localhost:8761/eureka>
 quarkus.eureka.metadata.<tag-key>=<tag value> #These keys values will be shown in Eureka registry if available i.e.: jhipster-registry
+quarkus.eureka.health-check-initial-delay= <delay in seconds before initially checking health before registration. Default 3>
 ----
 
 i.e: Given a `sample` application, your configuration properties to work with quarkus-eureka looks like:

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/config/DefaultInstanceInfoContextTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/config/DefaultInstanceInfoContextTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DefaultInstanceInfoContextTest {
 
     private EurekaRuntimeConfiguration eurekaRuntimeConfiguration;
+    private static final long HEALTH_CHECK_INITIAL_DELAY_DEFAULT = 3L;
 
     @BeforeEach
     void setUp() {
@@ -39,6 +40,7 @@ class DefaultInstanceInfoContextTest {
         eurekaRuntimeConfiguration.preferSameZone = true;
         eurekaRuntimeConfiguration.hostName = HostNameDiscovery.getHostname();
         eurekaRuntimeConfiguration.contextPath = "/";
+        eurekaRuntimeConfiguration.healthCheckInitialDelay = HEALTH_CHECK_INITIAL_DELAY_DEFAULT;
     }
 
     @Test
@@ -129,5 +131,32 @@ class DefaultInstanceInfoContextTest {
                 .containsEntry("context", "/").doesNotContainKey("tag").doesNotContainKey("app");
         assertThat(eurekaRuntimeConfiguration.metadata).isNull();
         Assertions.assertThat(instanceInfoContext.getMetadata()).isNotEmpty();
+    }
+
+    @Test
+    void shouldRegisterHealthCheckInitialDelay() {
+        final long expected = HEALTH_CHECK_INITIAL_DELAY_DEFAULT + 4L;
+
+        //Given
+        eurekaRuntimeConfiguration.healthCheckInitialDelay = expected;
+
+        //When
+        InstanceInfoContext instanceInfoContext = new DefaultInstanceInfoContext(eurekaRuntimeConfiguration);
+
+        //Then
+        assertThat(instanceInfoContext.getHealthCheckInitialDelay())
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldRegisterDefaultHealthCheckInitialDelay() {
+        final long expected = HEALTH_CHECK_INITIAL_DELAY_DEFAULT;
+
+        //When
+        InstanceInfoContext instanceInfoContext = new DefaultInstanceInfoContext(eurekaRuntimeConfiguration);
+
+        //Then
+        assertThat(instanceInfoContext.getHealthCheckInitialDelay())
+                .isEqualTo(expected);
     }
 }

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/registration/EurekaRegistrationServiceTest.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/registration/EurekaRegistrationServiceTest.java
@@ -82,7 +82,7 @@ class EurekaRegistrationServiceTest {
         wireMockServer.start();
 
         InstanceInfoContext instanceInfoContext = TestInstanceInfoContext.of(
-                appName, port, appName, hostname, "/", "/v1", "/info/status", "/info/health"
+                appName, port, appName, hostname, "/", "/v1", "/info/status", "/info/health", 3L
         );
         scheduledExecutorService = Mockito.mock(ScheduledExecutorService.class);
         registerOperation = new RegisterOperation();

--- a/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/test/config/TestInstanceInfoContext.java
+++ b/quarkus-eureka-deployment/src/test/java/io/quarkus/eureka/test/config/TestInstanceInfoContext.java
@@ -33,9 +33,10 @@ public class TestInstanceInfoContext implements InstanceInfoContext {
     private final String statusPageUrl;
     private final String healthCheckUrl;
     private final Map<String, String> metadata;
+    private final long healthCheckInitialDelay;
 
     private TestInstanceInfoContext(String name, int port, String vipAddress, String hostName,
-        String homePageUrl, String contextPath, String statusPageUrl, String healthCheckUrl) {
+        String homePageUrl, String contextPath, String statusPageUrl, String healthCheckUrl, long healthCheckInitialDelay) {
         this.name = name;
         this.port = port;
         this.vipAddress = vipAddress;
@@ -45,18 +46,19 @@ public class TestInstanceInfoContext implements InstanceInfoContext {
         this.hostName = hostName;
         this.instanceId = buildInstanceId();
         this.metadata = Map.of("context", contextPath);
+        this.healthCheckInitialDelay = healthCheckInitialDelay;
     }
 
     public static InstanceInfoContext of(final String name, final int port, final String hostName) {
 
-        return new TestInstanceInfoContext(name, port, name, hostName, "/", "/", "/info/status", "/info/health");
+        return new TestInstanceInfoContext(name, port, name, hostName, "/", "/", "/info/status", "/info/health", 3L);
     }
 
     public static InstanceInfoContext of(final String name, final int port, final String vipAddress,
         final String hostName, final String homePageUrl, final String contextPath,
-        final String statusPageUrl, final String healthCheckUrl) {
+        final String statusPageUrl, final String healthCheckUrl, final long healthCheckInitialDelay) {
         return new TestInstanceInfoContext(
-            name, port, vipAddress, hostName, homePageUrl, contextPath, statusPageUrl, healthCheckUrl
+            name, port, vipAddress, hostName, homePageUrl, contextPath, statusPageUrl, healthCheckUrl, healthCheckInitialDelay
         );
     }
 
@@ -106,5 +108,10 @@ public class TestInstanceInfoContext implements InstanceInfoContext {
 
     private String buildInstanceId() {
         return join(":", this.getHostName(), this.getName(), String.valueOf(this.getPort())).toLowerCase();
+    }
+
+    @Override
+    public long getHealthCheckInitialDelay() {
+        return healthCheckInitialDelay;
     }
 }

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/client/InstanceInfo.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/client/InstanceInfo.java
@@ -39,7 +39,8 @@ import static java.lang.String.format;
         "secureHealthCheckUrl",
         "port",
         "securePort",
-        "dataCenterInfo"
+        "dataCenterInfo",
+        "healthCheckInitialDelay"
 })
 public final class InstanceInfo {
 
@@ -58,6 +59,7 @@ public final class InstanceInfo {
     private final PortEnableInfo securePort;
     private final DataCenterInfo dataCenterInfo;
     private final Map<String, String> metadata;
+    private final long healthCheckInitialDelay;
 
     private InstanceInfo(final InstanceInfoContext instanceInfoCtx) {
         this.hostName = instanceInfoCtx.getHostName();
@@ -75,6 +77,7 @@ public final class InstanceInfo {
         this.dataCenterInfo = () -> DataCenterInfo.Name.MyOwn;
         this.instanceId = instanceInfoCtx.getInstanceId();
         this.metadata = instanceInfoCtx.getMetadata();
+        this.healthCheckInitialDelay = instanceInfoCtx.getHealthCheckInitialDelay();
     }
 
     private InstanceInfo(final InstanceInfo instanceInfo, final Status status) {
@@ -93,6 +96,7 @@ public final class InstanceInfo {
         this.dataCenterInfo = instanceInfo.getDataCenterInfo();
         this.instanceId = instanceInfo.getInstanceId();
         this.metadata = instanceInfo.getMetadata();
+        this.healthCheckInitialDelay = instanceInfo.getHealthCheckInitialDelay();
     }
 
     private String buildUrl(final int port, final String resourcePath) {
@@ -169,4 +173,9 @@ public final class InstanceInfo {
     public Map<String, String> getMetadata() {
         return this.metadata;
     }
+
+    public long getHealthCheckInitialDelay() {
+        return healthCheckInitialDelay;
+    }
+
 }

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/DefaultInstanceInfoContext.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/DefaultInstanceInfoContext.java
@@ -34,6 +34,7 @@ public class DefaultInstanceInfoContext implements InstanceInfoContext {
     private final String statusPageUrl;
     private final String healthCheckUrl;
     private final Map<String, String> metadata;
+    private final long healthCheckInitialDelay;
 
     DefaultInstanceInfoContext(final EurekaRuntimeConfiguration eurekaRuntimeConfiguration) {
         this.name = eurekaRuntimeConfiguration.name;
@@ -45,6 +46,7 @@ public class DefaultInstanceInfoContext implements InstanceInfoContext {
         this.hostName = selectedHostname(eurekaRuntimeConfiguration);
         this.instanceId = buildInstanceId();
         this.metadata = composeMetadata(eurekaRuntimeConfiguration);
+        this.healthCheckInitialDelay = eurekaRuntimeConfiguration.healthCheckInitialDelay;
     }
 
     private String selectedHostname(EurekaRuntimeConfiguration eurekaRuntimeConfiguration) {
@@ -99,6 +101,10 @@ public class DefaultInstanceInfoContext implements InstanceInfoContext {
 
     public Map<String, String> getMetadata() {
         return this.metadata;
+    }
+
+    public long getHealthCheckInitialDelay() {
+        return healthCheckInitialDelay;
     }
 
     private String buildInstanceId() {

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaRuntimeConfiguration.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/EurekaRuntimeConfiguration.java
@@ -113,6 +113,12 @@ public class EurekaRuntimeConfiguration {
     @ConfigItem(defaultValue = "/info/health")
     String healthCheckUrl;
 
+    /**
+     * Initial delay in seconds for health check before eureka registration
+     */
+    @ConfigItem(defaultValue = "3")
+    long healthCheckInitialDelay;
+
     public static class NetworkConverter implements Converter<String> {
 		private static final long serialVersionUID = -423310887944694372L;
 

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/config/InstanceInfoContext.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/config/InstanceInfoContext.java
@@ -29,4 +29,5 @@ public interface InstanceInfoContext {
     String getStatusPageUrl();
     String getHealthCheckUrl();
     Map<String, String> getMetadata();
+    long getHealthCheckInitialDelay();
 }

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/registration/EurekaRegistrationService.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/registration/EurekaRegistrationService.java
@@ -82,7 +82,7 @@ public class EurekaRegistrationService {
                 ).isNotRegistered(
                         queryResponse ->
                                 operationFactory.get(RegisterOperation.class).register(location, instanceInfo)
-                ), 3L, 40L, TimeUnit.SECONDS));
+                ), instanceInfo.getHealthCheckInitialDelay(), 40L, TimeUnit.SECONDS));
     }
 
     private static class RegistrationFlow {


### PR DESCRIPTION
Hi
Here is a sample merge request for
https://github.com/fmcejudo/quarkus-eureka/issues/48

* And one small grammar change in the README

Thanks