### PR TITLE
Update EurekaRecorder.java - BeanContainer method name changed instan…

### DIFF
--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/EurekaRecorder.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/EurekaRecorder.java
@@ -55,9 +55,9 @@ public class EurekaRecorder {
 
             OperationFactory operationFactory = createOperationFactory();
 
-            beanContainer.instance(EurekaProducer.class).setOperationFactory(operationFactory);
-            beanContainer.instance(EurekaProducer.class).setInstanceInfo(instanceInfo);
-            beanContainer.instance(EurekaProducer.class)
+            beanContainer.beanInstance(EurekaProducer.class).setOperationFactory(operationFactory);
+            beanContainer.beanInstance(EurekaProducer.class).setInstanceInfo(instanceInfo);
+            beanContainer.beanInstance(EurekaProducer.class)
                     .setServiceLocationConfig(serviceLocationConfig);
             new EurekaRegistrationService(serviceLocationConfig, instanceInfo, operationFactory)
                     .register();


### PR DESCRIPTION

BeanContainer method name changed instance => beanInstance

solution for error on quarkus version 3.10.0, method name changed.

public interface BeanContainer {
    <T> T beanInstance(Class<T> beanType, Annotation... beanQualifiers);
}

ERROR [io.qua.run.Application] (Quarkus Main Thread) Failed to start application (with profile [dev]): java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:111)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at io.quarkus.runner.bootstrap.StartupActionImpl$1.run(StartupActionImpl.java:113)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NoSuchMethodError: 'java.lang.Object io.quarkus.arc.runtime.BeanContainer.instance(java.lang.Class, java.lang.annotation.Annotation[])'
	at io.quarkus.eureka.EurekaRecorder.registerServiceInEureka(EurekaRecorder.java:58)
	at io.quarkus.deployment.steps.EurekaInfoProcessor$applyConfiguration1255836229.deploy_0(Unknown Source)
	at io.quarkus.deployment.steps.EurekaInfoProcessor$applyConfiguration1255836229.deploy(Unknown Source)
	... 11 more