### PR TITLE
Fix Run time configuration requirement introduced with Quarkus 3.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,16 +11,16 @@
     <url>https://github.com/fmcejudo/quarkus-eureka</url>
 
     <properties>
-        <compiler-plugin.version>3.11.0</compiler-plugin.version>
+        <compiler-plugin.version>3.15.0</compiler-plugin.version>
         <java.version>21</java.version>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.source>${java.version}</maven.compiler.source>
-        <quarkus.version>3.28.3</quarkus.version>
-        <wiremock.version>3.3.1</wiremock.version>
+        <quarkus.version>3.32.2</quarkus.version>
+        <wiremock.version>3.13.2</wiremock.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <checkstyle.config.location>./checkstyle.xml</checkstyle.config.location>
-        <assertj.version>3.25.3</assertj.version>
-        <surefire-plugin.version>3.0.0</surefire-plugin.version>
+        <assertj.version>3.27.7</assertj.version>
+        <surefire-plugin.version>3.5.5</surefire-plugin.version>
         <nexus.plugin.version>1.7.0</nexus.plugin.version>
     </properties>
 
@@ -105,7 +105,7 @@
                 <plugin>
                     <artifactId>io.quarkus</artifactId>
                     <groupId>quarkus-extension-maven-plugin</groupId>
-                    <version>3.10.0</version>
+                    <version>${quarkus.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -121,12 +121,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.6.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>9.2</version>
+                            <version>13.3.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -136,7 +136,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.3.1</version>
                 <configuration>
                     <localCheckout>true</localCheckout>
                     <pushChanges>false</pushChanges>
@@ -147,14 +147,14 @@
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
                         <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.9.5</version>
+                        <version>2.2.1</version>
                     </dependency>
                 </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.9.0</version>
+                <version>0.10.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
@@ -163,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -206,9 +206,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
                 <configuration>
-                    <configLocation>./checkstyle.xml</configLocation>
+                    <configLocation>${checkstyle.config.location}</configLocation>
                 </configuration>
             </plugin>
         </plugins>
@@ -284,7 +283,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.2.8</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/quarkus-eureka-deployment/pom.xml
+++ b/quarkus-eureka-deployment/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-junit5</artifactId>
+            <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -92,7 +92,6 @@
                         <path>
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-extension-processor</artifactId>
-                            <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/quarkus-eureka-deployment/src/main/java/io/quarkus/eureka/EurekaInfoProcessor.java
+++ b/quarkus-eureka-deployment/src/main/java/io/quarkus/eureka/EurekaInfoProcessor.java
@@ -24,7 +24,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.eureka.config.EurekaBuildTimeConfiguration;
-import io.quarkus.eureka.config.EurekaRuntimeConfiguration;
 import io.quarkus.eureka.heartbeat.HealthCheckController;
 import io.quarkus.eureka.heartbeat.StatusCheckController;
 import io.quarkus.undertow.deployment.ServletBuildItem;
@@ -35,9 +34,8 @@ public class EurekaInfoProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     @BuildStep
     public void applyConfiguration(final EurekaRecorder eurekaRecorder,
-        final EurekaRuntimeConfiguration eurekaRuntimeConfiguration,
         final BeanContainerBuildItem beanContainer) {
-        eurekaRecorder.registerServiceInEureka(eurekaRuntimeConfiguration, beanContainer.getValue());
+        eurekaRecorder.registerServiceInEureka(beanContainer.getValue());
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/quarkus-eureka/pom.xml
+++ b/quarkus-eureka/pom.xml
@@ -73,6 +73,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
                 <!-- Executions configuration can be inherited from quarkus-build-parent -->
                 <executions>
                     <execution>

--- a/quarkus-eureka/pom.xml
+++ b/quarkus-eureka/pom.xml
@@ -73,7 +73,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
-                <version>3.10.0</version>
                 <!-- Executions configuration can be inherited from quarkus-build-parent -->
                 <executions>
                     <execution>
@@ -96,7 +95,6 @@
                         <path>
                             <groupId>io.quarkus</groupId>
                             <artifactId>quarkus-extension-processor</artifactId>
-                            <version>${quarkus.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/quarkus-eureka/src/main/java/io/quarkus/eureka/EurekaRecorder.java
+++ b/quarkus-eureka/src/main/java/io/quarkus/eureka/EurekaRecorder.java
@@ -27,6 +27,7 @@ import io.quarkus.eureka.operation.query.SingleInstanceQueryOperation;
 import io.quarkus.eureka.operation.register.RegisterOperation;
 import io.quarkus.eureka.operation.remove.RemoveInstanceOperation;
 import io.quarkus.eureka.registration.EurekaInstancesRegistration;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import jakarta.ws.rs.ProcessingException;
 
@@ -41,9 +42,16 @@ import static java.util.Arrays.asList;
 public class EurekaRecorder {
 
     private final Logger logger = Logger.getLogger(this.getClass().getName());
+    private final RuntimeValue<EurekaRuntimeConfiguration> eurekaRuntimeConfigurationValue;
 
-    public void registerServiceInEureka(final EurekaRuntimeConfiguration eurekaRuntimeConfiguration,
-                                        final BeanContainer beanContainer) {
+    public EurekaRecorder(
+            final RuntimeValue<EurekaRuntimeConfiguration> eurekaRuntimeConfigurationValue) {
+        this.eurekaRuntimeConfigurationValue = eurekaRuntimeConfigurationValue;
+    }
+
+    public void registerServiceInEureka(final BeanContainer beanContainer) {
+        EurekaRuntimeConfiguration eurekaRuntimeConfiguration =
+                eurekaRuntimeConfigurationValue.getValue();
         if(!eurekaRuntimeConfiguration.enable()) {
             return;
         }


### PR DESCRIPTION
Quarkus 3.32 changed run time configuration requirements for extensions:

```
[ERROR] Caused by: java.lang.IllegalArgumentException: Run time configuration cannot be consumed 
in Build Steps, 
use RuntimeValue<io.quarkus.eureka.config.EurekaRuntimeConfiguration> in a @Recorder constructor instead at 
final io.quarkus.eureka.config.EurekaRuntimeConfiguration eurekaRuntimeConfiguration of 
public void io.quarkus.eureka.EurekaInfoProcessor.applyConfiguration(
    io.quarkus.eureka.EurekaRecorder,io.quarkus.eureka.config.EurekaRuntimeConfiguration,
    io.quarkus.arc.deployment.BeanContainerBuildItem) 
of class io.quarkus.eureka.EurekaInfoProcessor
```

So `eurekaRuntimeConfigurationValue` is now injected via constructor into `EurekaRecorder` as `RuntimeValue<EurekaRuntimeConfiguration>`.

Also bumped the versions of several dependencies and removed redundant version declarations from POM.